### PR TITLE
Add alternative input formats to metadata, phenotypes, summary, & variants functions

### DIFF
--- a/plco.js
+++ b/plco.js
@@ -136,14 +136,35 @@ plco.api.download = async (
     return await plco.api.get((cmd = 'download'), parms)
 }
 
-// Example call: await plco.api.metadata({ phenotype_id: 3080, sex: "female", ancestry: "european" })
-plco.api.metadata = async (parms) => {
-    parms = typeof parms == 'string' ? plco.api.string2parms(parms) : parms
+/**
+ * Retrieves metadata for phenotypes specified
+ * @param {object | string | *[][]} parms An object, query string, or 2-d array that contains the query parameters.
+ * @param {number} phenotype_id A phenotype id.
+ * @param {string} sex A sex, which may be "all", "female", or "male".
+ * @param {string} ancestry A character vector specifying ancestries to retrieve data for.
+ * @param {string} raw _Optional_. If true, returns data in an array of arrays instead of an array of objects.
+ * @return A dataframe containing phenotype metadata
+ * @examples
+ * plco.api.metadata()
+ * plco.api.metadata({ phenotype_id: 3080, sex: "female", ancestry: "european" })
+ * plco.api.metadata("phenotype_id=3080&sex=female&ancestry=european")
+ * plco.api.metadata([["phenotype_id",3080], ["sex","female"], ["ancestry","european"]])
+ * plco.api.metadata({}, 3080, "female", "european")
+*/
+plco.api.metadata = async (
+    parms, 
+    phenotype_id = 3080, 
+    sex = "female", 
+    ancestry = "european", 
+    raw = undefined
+) => {
+    parms = typeof parms == 'string' ? plco.api.string2parms(parms) : Array.isArray(parms) ? Object.fromEntries(parms) : parms
     parms = parms || {
-        phenotype_id: 3080,
-        sex: "female",
-        ancestry: "european"
+        phenotype_id,
+        sex,
+        ancestry
     }
+    plco.defineAttributes(parms, { phenotype_id, sex, ancestry }, { raw })
     return await plco.api.get((cmd = 'metadata'), parms)
 }
 
@@ -169,37 +190,129 @@ plco.api.participants = async (
     return await plco.api.get((cmd = 'participants'), parms)
 }
 
-// Example call: await plco.api.phenotypes({ q: "first_ca125_level" })
-plco.api.phenotypes = async (parms) => {
-    parms = typeof (parms) == "string" ? plco.api.string2parms(parms) : parms
+/**
+ * Retrieves phenotypes
+ * @param {object | string | *[][]} parms An object, query string, or 2-d array that contains the query parameters.
+ * @param {string} q _Optional_. A query term
+ * @param {string} raw _Optional_. If true, returns data in an array of arrays instead of an array of objects.
+ * @return If query is specified, a list of phenotypes that contain the query term is returned. Otherwise, a tree of all phenotypes is returned.
+ * @examples
+ * plco.api.phenotypes()
+ * plco.api.phenotypes({ q: "first_ca125_level" })
+ * plco.api.phenotypes("q=first_ca125_level")
+ * plco.api.phenotypes([["q","first_ca125_level"]])
+ * plco.api.phenotypes({}, "first_ca125_level")
+*/
+plco.api.phenotypes = async (
+    parms, 
+    q = undefined, 
+    raw = undefined
+) => {
+    parms = typeof parms == 'string' ? plco.api.string2parms(parms) : Array.isArray(parms) ? Object.fromEntries(parms) : parms
+    parms = parms || {
+    }
+    plco.defineAttributes(parms, { }, { q, raw })
     return await plco.api.get(cmd = "phenotypes", parms)
 }
 
-// Example call: await plco.api.summary({ phenotype_id: 3080, sex: "female", ancestry: "european", p_value_nlog_min: 4 })
-plco.api.summary = async (parms) => {
-    parms = typeof (parms) == "string" ? plco.api.string2parms(parms) : parms
+/**
+ * Retrieve variants for all chromosomes at a resolution of 400x800 bins across the whole genome and specified -log10(p) range
+ * @param {object | string | *[][]} parms An object, query string, or 2-d array that contains the query parameters.
+ * @param {number} phenotype_id A phenotype id.
+ * @param {string} sex A sex, which may be "all", "female", or "male".
+ * @param {string} ancestry A character vector specifying ancestries to retrieve data for.
+ * @param {number} p_value_nlog_min A numeric value >= 0 specifying the minimum -log10(p) for variants.
+ * @param {string} raw _Optional_. If true, returns data in an array of arrays instead of an array of objects.
+ * @return A dataframe with aggregated variants.
+ * @examples
+ * plco.api.summary()
+ * plco.api.summary({ phenotype_id: 3080, sex: "female", ancestry: "european", p_value_nlog_min: 4 })
+ * plco.api.summary("phenotype_id=3080&sex=female&ancestry=european&p_value_nlog_min=4")
+ * plco.api.summary([["phenotype_id",3080], ["sex","female"], ["ancestry","european"], ["p_value_nlog_min",4]])
+ * plco.api.summary({}, 3080, "female", "european", 4)
+*/
+plco.api.summary = async (
+    parms, 
+    phenotype_id = 3080, 
+    sex = "female", 
+    ancestry = "european", 
+    p_value_nlog_min = 4, 
+    raw = undefined
+) => {
+    parms = typeof parms == 'string' ? plco.api.string2parms(parms) : Array.isArray(parms) ? Object.fromEntries(parms) : parms
     parms = parms || {
-        phenotype_id: 3080,
-        sex: "female",
-        ancestry: "european",
-        p_value_nlog_min: 4
+        phenotype_id,
+        sex,
+        ancestry,
+        p_value_nlog_min
     }
+    plco.defineAttributes(parms, { phenotype_id, sex, ancestry, p_value_nlog_min }, { raw })
     return await plco.api.get(cmd = "summary", parms)
-    //phenotype_id=3080&sex=all&ancestry=east_asian&p_value_nlog_min=4"
 }
 
-// Example call: await plco.api.variants({ phenotype_id: 3080, sex: "female", ancestry: "european", chromosome: 8,
-// p_value_nlog_min: 4,  limit: 10 })
-plco.api.variants = async (parms)  => {
-    parms = typeof (parms) == "string" ? plco.api.string2parms(parms) : parms
+/**
+ * Retrieve variants for specified phenotype, sex, ancestry, chromosome, and other optional fields.
+ * @param {object | string | *[][]} parms An object, query string, or 2-d array that contains the query parameters.
+ * @param {number} phenotype_id Phenotype id(s)
+ * @param {string} sex A sex, which may be "all", "female", or "male".
+ * @param {string} ancestry An ancestry, which may be "african_american", "east_asian", or "european".
+ * @param {number} chromosome A chromosome number.
+ * @param {string} columns _Optional_ Properties for each variant. Default: all properties.
+ * @param {string} snp _Optional_ Snps.
+ * @param {number} position _Optional_ The exact position of the variant within a chromosome.
+ * @param {number} position_min _Optional_ The minimum chromosome position for variants.
+ * @param {number} position_max _Optional_ The maximum chromosome position for variants.
+ * @param {number} p_value_nlog_min _Optional_ The minimum -log10(p) of variants in the chromosome.
+ * @param {number} p_value_nlog_max _Optional_ The maximum -log10(p) of variants in the chromosome.
+ * @param {number} p_value_min _Optional_ The minimum p-value of variants in the chromosome.
+ * @param {number} p_value_max _Optional_ The maximum p-value of variants in the chromosome.
+ * @param {string} orderBy _Optional_ A property to order variants by. May be "id", "snp", "chromosome", "position", "p_value", or "p_value_nlog".
+ * @param {string} order _Optional_ An order in which to sort variants. May be "asc" or "desc".
+ * @param {number} offset _Optional_ The number of records by which to offset the variants (for pagination)
+ * @param {number} limit _Optional_ The maximum number of variants to return (for pagination). Highest allowed value is 1 million.
+ * @param {string} raw _Optional_. If true, returns data in an array of arrays instead of an array of objects.
+ * @return A dataframe with variants.
+ * @examples
+ * plco.api.variants()
+ * plco.api.variants({ phenotype_id: 3080, sex: "female", ancestry: "european", chromosome: 8, limit: 10 })
+ * plco.api.variants("phenotype_id=3080&sex=female&ancestry=european&chromosome=8&limit=10")
+ * plco.api.variants([["phenotype_id",3080], ["sex","female"], ["ancestry","european"], ["chromosome",8], ["limit",10]])
+ * plco.api.variants({}, 3080, "female", "european", 8)
+*/
+plco.api.variants = async (
+    parms, 
+    phenotype_id = 3080, 
+    sex = "female", 
+    ancestry = "european", 
+    chromosome = 8, 
+    columns = undefined, 
+    snp = undefined,
+    position = undefined,
+    position_min = undefined,
+    position_max = undefined,
+    p_value_nlog_min = undefined,
+    p_value_nlog_max = undefined,
+    p_value_min = undefined,
+    p_value_max = undefined,
+    orderBy = undefined,
+    order = undefined,
+    offset = undefined,
+    limit = undefined,
+    raw = undefined
+)  => {
+    parms = typeof parms == 'string' ? plco.api.string2parms(parms) : Array.isArray(parms) ? Object.fromEntries(parms) : parms
     parms = parms || {
-        phenotype_id: 3080,
-        sex: "female",
-        ancestry: "european",
-        chromosome: 8,
-        p_value_nlog_min: 1.3,
+        phenotype_id,
+        sex,
+        ancestry,
+        chromosome,
         limit: 10
     }
+    plco.defineAttributes(
+        parms, 
+        { phenotype_id, sex, ancestry, chromosome }, 
+        { columns, snp, position, position_min, position_max, p_value_nlog_min, p_value_nlog_max, p_value_min, p_value_max, orderBy, order, offset, limit, raw }
+    )
     return await plco.api.get(cmd = "variants", parms)
 }
 

--- a/plco.js
+++ b/plco.js
@@ -200,7 +200,7 @@ plco.api.variants = async (parms)  => {
         p_value_nlog_min: 1.3,
         limit: 10
     }
-    return await plco.api.get(cmd = "summary", parms)
+    return await plco.api.get(cmd = "variants", parms)
 }
 
 /*


### PR DESCRIPTION
- Added two new allowable input formats:
    - Array of arrays that contain key value pairs
    - Values of parameters only (must occur in order shown in function definition)
- Also added documentation for metadata, phenotypes, summary, and variants functions