### PR TITLE
proper parse before proper stringification

### DIFF
--- a/plco.js
+++ b/plco.js
@@ -54,7 +54,7 @@ plco.saveFile = (url) => {
  */
 plco.downloadJSON = (contents, fileName = 'plot') => {
     const a = document.createElement('a')
-    a.href = URL.createObjectURL(new Blob([JSON.stringify(contents, null, 2)], {
+    a.href = URL.createObjectURL(new Blob([JSON.stringify(JSON.parse(contents))], {
         type: 'text/plain'
     }))
     a.setAttribute('download', fileName + '.json')


### PR DESCRIPTION
the original was producing JSON as a string:

"{\"traces\":[{\"x\":[33326874,27390488,698 ...

this would not be a valid json file. This was fixed by parsing to proper JSON before stringifying it, as

{"traces":[{"x":[33326874,27390488,698 ...