### PR TITLE
converging syntax for import api and plot

### DIFF
--- a/export.js
+++ b/export.js
@@ -17,8 +17,8 @@ await loadScript('https://episphere.github.io/plco/plco.js')
 function defineProperties() { return plco.defineProperties };
 function explorePhenotypes() { return plco.explorePhenotypes };
 function saveFile() { return plco.saveFile };
-function api() { return plco.api };
-function plot() { return plco.plot };
+function api() { return plco.api };api=api()
+function plot() { return plco.plot };plot=plot()
 const help = 'https://episphere.github.io/plco';
 const docs = 'https://episphere.github.io/plco/docs';
 


### PR DESCRIPTION
to make sure the syntax is exactly the same no matter how the library was loaded. For example, import, erequire and srcipt tag all should allow for a plco.api.ping() to work. Up to now, the import route requires a "()" as plco.api().ping()